### PR TITLE
feat: use $HOME/.cache/ygh as install dir for pkgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Use it like this
 
 The plan is to support more of the `pacman` commands. Look into the ALPM project and maybe use it instead of calling makepkg via command execute.  
 Investigate how to implement updates.  
-Saving the repos elsewhere, instead of inside `/tmp` repo.  
 Etc.
 
 ## Should you use this as your main AUR helper?

--- a/main.go
+++ b/main.go
@@ -21,13 +21,7 @@ func main() {
 	flag.Parse()
 	packageNames := flag.Args()
 
-	installLoc := "/tmp/ygh"
-	if _, err := os.Stat(installLoc); os.IsNotExist(err) {
-		err := os.Mkdir(installLoc, 0755)
-		if err != nil {
-			log.Fatalln("error creating '/tmp/ygh' directory")
-		}
-	}
+	installLoc := setupInstallDir()
 
 	for _, pkg := range packageNames {
 		url := fmt.Sprintf("https://raw.githubusercontent.com/archlinux/aur/refs/heads/%s/PKGBUILD", pkg)
@@ -73,6 +67,22 @@ func main() {
 			fmt.Println(err)
 		}
 	}
+}
+
+func setupInstallDir() string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		log.Fatalln("Error getting user home directory")
+	}
+
+	installLoc := homeDir + "/.cache/ygh"
+	if _, err := os.Stat(installLoc); os.IsNotExist(err) {
+		err := os.Mkdir(installLoc, 0755)
+		if err != nil {
+			log.Fatalln("error creating" + installLoc + " directory")
+		}
+	}
+	return installLoc
 }
 
 func handlePKGBUILDShowing(body []byte, pkg string) bool {


### PR DESCRIPTION
Using tmp is to limiting and reduces performance for updating
